### PR TITLE
Avoid error when switching language.

### DIFF
--- a/lib/Apache2/Filter/WOVN/OutputFilter.pm
+++ b/lib/Apache2/Filter/WOVN/OutputFilter.pm
@@ -39,8 +39,10 @@ sub handler {
     }
 
     $Plack::Middleware::WOVN::STORE = $Apache2::Filter::WOVN::STORE;
-    $body = Plack::Middleware::WOVN::switch_lang( $body, $values, $url,
-        $Apache2::Filter::WOVN::LANG, $Apache2::Filter::WOVN::HEADERS );
+    $body                           = eval {
+        Plack::Middleware::WOVN::switch_lang( $body, $values, $url,
+            $Apache2::Filter::WOVN::LANG, $Apache2::Filter::WOVN::HEADERS );
+    } || $body;
 
     $f->print($body);
     return Apache2::Const::DECLINED;


### PR DESCRIPTION
Error message:

> [Wed Jun 01 13:15:50 2016] [error] [client 192.168.33.1] Malformed UTF-8 character (fatal) at /usr/local/share/perl5/HTML/HTML5/Entities.pm line 2611, <DATA> line 2125.\n
